### PR TITLE
Better acknowledgment of order including device name

### DIFF
--- a/fr/commands
+++ b/fr/commands
@@ -1,2 +1,2 @@
-*ALLUME*==pg_jc_turn on "$order" && say "Voilà"
-*ETEIN*==pg_jc_turn off "$order" && say "Voilà"
+*OUVRE*|*ALLUME*|*MONTE*|*MARCHE*==turn on "$order"
+*FERME*|*ETEIN*|*DESCEND*|*ARRET*|*STOP*|*ARRETE*L*==turn off "$order"

--- a/fr/functions.sh
+++ b/fr/functions.sh
@@ -2,19 +2,26 @@
 # Here you can create functions which will be available from the commands file
 # You can also use here user variables defined in your config file
 
-pg_jc_turn () {
+turn () {
     # $1: action [on|off]
     # $2: received order
     [ "$1" == "off" ] && local url="$pg_hc_turnoff_url" || local url="$pg_hc_turnon_url"
     local -r order="$(jv_sanitize "$2")"
+
+
     while read device; do
         local sdevice="$(jv_sanitize "$device" ".*")"
-        if [[ "$order" =~ .*$sdevice.* ]]; then
+
+	if [[ "$order" =~ .*$sdevice.* ]]; then
             local address="$(echo $pg_hc_config | jq -r ".devices[] | select(.name==\"$device\") | .address")"
             jv_curl "${url//\[ADDRESS\]/$address}"
+	    say "voilà commande ok pour $2"
             return $?
         fi
+
     done <<< "$(echo $pg_hc_config | jq -r '.devices[].name')"
-    jv_error "ERROR: no device maching $2"
-    return 1
+say "erreur: Commande non reconnu pour la piece $2"
+
+    # jv_error $"erreur: Commande non reconnu pour $2"
+    # return 1
 }


### PR DESCRIPTION
Description

If your home automation system can be controlled via http requests, this
Jarvis plugin is just for you. It will allow you to simply turn on and
off your devices.

Configuration

Indicate the turn on and turn off http urls (with [ADDRESS]
placeholder):

pg_hc_turnon_url="http://192.168.1.1/home.php?action=on&device=[ADDRESS]"

pg_hc_turnoff_url="http://192.168.1.1/home.php?action=off&device=[ADDRESS]"
List your device names & corresponding addresses in json format

pg_hc_config='{ "devices":[
{ "name": "BEDROOM", "address": "A1"},
{ "name": "LIVING ROOM", "address": "A2"},
{ "name": "BAR", "address": "A3"}
]}'
Usage

You: turn on the bar
# > http://192.168.1.1/home.php?action=on&device=A3
Jarvis: Done
Author

alexylem